### PR TITLE
Added file closing functionality and added another unicode validation

### DIFF
--- a/pygbx/gbx.py
+++ b/pygbx/gbx.py
@@ -7,11 +7,13 @@ import zlib
 import pygbx.headers as headers
 from pygbx.bytereader import ByteReader
 
+
 class GbxType(IntEnum):
     """Represents the type of the main or auxiliary class contained within the GBX file.
 
     Some classes may have a different or multiple ID's, depending on what version of the GBX file is being parsed.
     """
+
     CHALLENGE = 0x03043000
     CHALLENGE_OLD = 0x24003000
     COLLECTOR_LIST = 0x0301B000
@@ -23,7 +25,7 @@ class GbxType(IntEnum):
     REPLAY_RECORD_OLD = 0x02407E000
     GAME_GHOST = 0x0303F005
     CTN_GHOST = 0x03092000
-    CTN_GHOST_OLD = 0x2401B000 
+    CTN_GHOST_OLD = 0x2401B000
     CTN_COLLECTOR = 0x0301A000
     CTN_OBJECT_INFO = 0x0301C000
     CTN_DECORATION = 0x03038000
@@ -33,8 +35,10 @@ class GbxType(IntEnum):
     MW_NOD = 0x01001000
     UNKNOWN = 0x0
 
+
 class GbxLoadError(Exception):
     """Thrown when the Gbx class fails to parse the provided Gbx object"""
+
     def __init__(self, message):
         """Initializes the Exception instance with a message.
 
@@ -65,7 +69,7 @@ class Gbx(object):
 
         Parses the Gbx file sequentially, reading all supported chunks until no more chunks have
         been found. Parsing can fail depending on the what classes or chunks it contains and what
-        version of the GBX file is being parsed. 
+        version of the GBX file is being parsed.
 
         Args:
             obj (str/bytes): a file path to the Gbx file or bytes object containing the Gbx data
@@ -74,15 +78,25 @@ class Gbx(object):
             GbxLoadError: raised when the supplied object is not a GBX file or data
         """
         if isinstance(obj, str):
-            self.f = open(obj, 'rb')
+            self.f = open(obj, "rb")
             self.root_parser = ByteReader(self.f)
         else:
             self.root_parser = ByteReader(obj)
 
-        self.magic = self.root_parser.read(3, '3s')
-        if self.magic.decode('utf-8') != 'GBX':
-            raise GbxLoadError(f'obj is not a valid Gbx data: magic string is incorrect')
-        self.version = self.root_parser.read(2, 'H')
+        self.magic = self.root_parser.read(3, "3s")
+
+        try:
+            self.magic.decode("utf-8")
+        except:
+            self.close()
+            raise GbxLoadError(f"obj is not a valid Gbx data: can not decode unicode")
+
+        if self.magic.decode("utf-8") != "GBX":
+            self.close()
+            raise GbxLoadError(
+                f"obj is not a valid Gbx data: magic string is incorrect"
+            )
+        self.version = self.root_parser.read(2, "H")
         self.classes = {}
         self.root_classes = {}
         self.positions = {}
@@ -125,7 +139,7 @@ class Gbx(object):
                     self.root_parser.skip(4)
 
         self.root_parser.push_info()
-        self.positions['data_size'] = self.root_parser.pop_info()
+        self.positions["data_size"] = self.root_parser.pop_info()
 
         data_size = self.root_parser.read_uint32()
         compressed_data_size = self.root_parser.read_uint32()
@@ -134,6 +148,11 @@ class Gbx(object):
 
         bp = ByteReader(self.data)
         self._read_node(self.class_id, -1, bp)
+
+    """Closes the current file connection"""
+
+    def close(self):
+        self.f.close()
 
     def __read_sub_folder(self):
         num_sub_folders = self.root_parser.read_uint32()
@@ -153,6 +172,7 @@ class Gbx(object):
         ByteParser with the current position set right after the chunk ID, or None
         if no specified chunk ID was found
     """
+
     def find_raw_chunk_id(self, chunk_id):
         bp = ByteReader(self.data[:])
         for i in range(len(self.data) - 4):
@@ -164,13 +184,13 @@ class Gbx(object):
 
     def get_class_by_id(self, class_id):
         """Finds the header that corresponds to the provided class ID.
-        
+
         This is a wrapper around get_classes_by_ids that returns the first
         element if any headers have been found for a single ID. See get_classes_by_ids for more details.
 
         Args:
             class_id (int): the class ID to be retrieved
-        
+
         Returns:
             a single instance of the header corresponding to the provided class ID
         """
@@ -191,7 +211,7 @@ class Gbx(object):
 
         Returns:
             a list of matched headers
-        """        
+        """
         classes = []
         for cl in list(self.classes.values()) + list(self.root_classes.values()):
             if cl.id in class_ids:
@@ -204,7 +224,7 @@ class Gbx(object):
 
         self.root_parser.push_info()
         self.user_data_size = self.root_parser.read_uint32()
-        self.positions['user_data_size'] = self.root_parser.pop_info()
+        self.positions["user_data_size"] = self.root_parser.pop_info()
 
         user_data_pos = self.root_parser.pos
         num_chunks = self.root_parser.read_uint32()
@@ -245,7 +265,7 @@ class Gbx(object):
 
                         if version == 6:
                             self.root_parser.skip(4)
-                        
+
                         if version >= 7:
                             self.root_parser.read_uint32()
 
@@ -257,7 +277,7 @@ class Gbx(object):
 
                                     if version >= 11:
                                         self.root_parser.skip(4)
-                                        
+
                                         if version >= 12:
                                             self.root_parser.skip(4)
 
@@ -274,7 +294,7 @@ class Gbx(object):
 
             self.root_parser.push_info()
             game_class.track_name = self.root_parser.read_string()
-            self.positions['track_name'] = self.root_parser.pop_info()
+            self.positions["track_name"] = self.root_parser.pop_info()
 
             self.root_parser.read_byte()
 
@@ -285,14 +305,16 @@ class Gbx(object):
             self.__community = self.root_parser.read_string()
         elif cid == 0x03093000 or cid == 0x2403F000:
             version = self.root_parser.read_uint32()
-            self.__replay_header_info['version'] = version
+            self.__replay_header_info["version"] = version
             if version >= 2:
                 for _ in range(3):
                     self.root_parser.read_string_lookback()
                 self.root_parser.skip(4)
-                self.__replay_header_info['nickname'] = self.root_parser.read_string()
+                self.__replay_header_info["nickname"] = self.root_parser.read_string()
                 if version >= 6:
-                    self.__replay_header_info['driver_login'] = self.root_parser.read_string()
+                    self.__replay_header_info[
+                        "driver_login"
+                    ] = self.root_parser.read_string()
                     self.root_parser.skip(1)
                     self.root_parser.read_string_lookback()
         elif cid == 0x03093002 or cid == 0x2403F002:
@@ -308,14 +330,14 @@ class Gbx(object):
 
         if class_id == GbxType.CHALLENGE or class_id == GbxType.CHALLENGE_OLD:
             game_class = headers.CGameChallenge(class_id)
-            if hasattr(self, '__community'):
+            if hasattr(self, "__community"):
                 game_class.community = self.__community
         elif class_id == GbxType.REPLAY_RECORD or class_id == GbxType.REPLAY_RECORD_OLD:
             game_class = headers.CGameReplayRecord(class_id)
-            if 'nickname' in self.__replay_header_info:
-                game_class.nickname = self.__replay_header_info['nickname']
-            if 'driver_login' in self.__replay_header_info:
-                game_class.driver_login = self.__replay_header_info['driver_login']
+            if "nickname" in self.__replay_header_info:
+                game_class.nickname = self.__replay_header_info["nickname"]
+            if "driver_login" in self.__replay_header_info:
+                game_class.driver_login = self.__replay_header_info["driver_login"]
 
         elif class_id == GbxType.WAYPOINT_SPECIAL_PROP or class_id == 0x2E009000:
             game_class = headers.CGameWaypointSpecialProperty(class_id)
@@ -338,10 +360,10 @@ class Gbx(object):
         while True:
             oldcid = cid
             cid = bp.read_uint32()
-            logging.debug(f'Reading chunk {hex(cid)}')
+            logging.debug(f"Reading chunk {hex(cid)}")
 
             if cid == 0xFACADE01:
-                logging.debug('Encountered chunk 0xFACADE01, stopping')
+                logging.debug("Encountered chunk 0xFACADE01, stopping")
                 break
 
             skipsize = -1
@@ -378,10 +400,10 @@ class Gbx(object):
                 bp.read_string()
             elif cid == 0x0305B004 or cid == 0x2400C004:
                 game_class.times = {
-                    'bronze': bp.read_int32(),
-                    'silver': bp.read_int32(),
-                    'gold': bp.read_int32(),
-                    'author': bp.read_int32()
+                    "bronze": bp.read_int32(),
+                    "silver": bp.read_int32(),
+                    "gold": bp.read_int32(),
+                    "author": bp.read_int32(),
                 }
 
                 bp.read_uint32()
@@ -393,7 +415,7 @@ class Gbx(object):
             elif cid == 0x0305B008 or cid == 0x2400C008:
                 bp.skip(2 * 4)
             elif cid == 0x0305B00A:
-                bp.skip(9 * 4)                
+                bp.skip(9 * 4)
             elif cid == 0x0305B00D:
                 bp.skip(1 * 4)
             elif cid == 0x03043014 or cid == 0x03043029:
@@ -401,8 +423,8 @@ class Gbx(object):
                 # m = hashlib.md5()
                 # m.update(bp.read(16))
                 # if isinstance(self.__current_class, headers.CGameChallenge):
-                    # self.__current_class.password_hash = m.hexdigest()
-                    # self.__current_class.password_crc = bp.read_uint32()
+                # self.__current_class.password_hash = m.hexdigest()
+                # self.__current_class.password_crc = bp.read_uint32()
             elif cid == 0x03043017:
                 num_cps = bp.read_uint32()
                 for _ in range(num_cps):
@@ -417,18 +439,18 @@ class Gbx(object):
 
                 bp.push_info()
                 game_class.map_name = bp.read_string()
-                self.positions['map_name'] = bp.pop_info()
+                self.positions["map_name"] = bp.pop_info()
 
                 bp.push_info()
                 game_class.mood = bp.read_string_lookback()
-                self.positions['mood'] = bp.pop_info()
+                self.positions["mood"] = bp.pop_info()
                 game_class.env_bg = bp.read_string_lookback()
                 game_class.env_author = bp.read_string_lookback()
 
                 game_class.map_size = (
                     bp.read_int32(),
                     bp.read_int32(),
-                    bp.read_int32()
+                    bp.read_int32(),
                 )
 
                 game_class.req_unlock = bp.read_int32()
@@ -440,13 +462,11 @@ class Gbx(object):
                 while i < num_blocks:
                     block = headers.MapBlock()
                     block.name = bp.read_string_lookback()
-                    if block.name != 'Unassigned1':
+                    if block.name != "Unassigned1":
                         game_class.blocks.append(block)
                     block.rotation = bp.read_byte()
                     block.position = headers.Vector3(
-                        bp.read_byte(),
-                        bp.read_byte(),
-                        bp.read_byte()
+                        bp.read_byte(), bp.read_byte(), bp.read_byte()
                     )
 
                     if game_class.flags > 0:
@@ -461,7 +481,7 @@ class Gbx(object):
                         block.skin_author = bp.read_string_lookback()
                         if game_class.flags >= 6:
                             # TM2 flags
-                            bp.read_string() # Block waypoint type {Spawn, Goal}
+                            bp.read_string()  # Block waypoint type {Spawn, Goal}
                             bp.read_int32()
                             self._read_node(0x2E009000, 0, bp, False)
                         else:
@@ -478,7 +498,7 @@ class Gbx(object):
 
                     i += 1
 
-                self.positions['block_data'] = bp.pop_info()              
+                self.positions["block_data"] = bp.pop_info()
             elif cid == 0x03043022:
                 bp.skip(4)
             elif cid == 0x03043024:
@@ -601,7 +621,7 @@ class Gbx(object):
                 try:
                     game_class.track = Gbx(data)
                 except Exception as e:
-                    logging.error(f'Failed to parse map data: {e}')
+                    logging.error(f"Failed to parse map data: {e}")
 
             elif cid == 0x03093007:
                 bp.skip(4)
@@ -613,7 +633,7 @@ class Gbx(object):
                     if idx >= 0 and idx not in self.classes:
                         _class_id = bp.read_uint32()
                         self._read_node(_class_id, idx, bp)
-                
+
                 bp.skip(4)
                 # num_extras = bp.read_uint32()
                 # bp.skip(num_extras * 8)
@@ -635,7 +655,7 @@ class Gbx(object):
                 version = bp.read_byte()
                 if version >= 3:
                     bp.skip(32)
-                
+
                 path = bp.read_string()
                 if len(path) > 0 and version >= 1:
                     bp.read_string()
@@ -665,7 +685,7 @@ class Gbx(object):
                 for i in range(num):
                     cp_times.append(bp.read_uint32())
                     bp.skip(4)
-                
+
                 game_class.cp_times = cp_times
             elif cid == 0x309200C or cid == 0x2401B00C:
                 bp.skip(4)
@@ -673,8 +693,10 @@ class Gbx(object):
                 game_class.uid = bp.read_string_lookback()
 
                 # For TM2
-                if ('version' in self.__replay_header_info
-                    and self.__replay_header_info['version'] >= 8):
+                if (
+                    "version" in self.__replay_header_info
+                    and self.__replay_header_info["version"] >= 8
+                ):
                     pos = bp.pos
                     try:
                         game_class.login = bp.read_string()
@@ -702,11 +724,16 @@ class Gbx(object):
                 bp.read_string_lookback()
                 bp.read_string_lookback()
                 bp.read_string_lookback()
-            elif cid == 0x3092019 or cid == 0x03092025 or cid == 0x2401B019 or cid == 0x2401B011:
+            elif (
+                cid == 0x3092019
+                or cid == 0x03092025
+                or cid == 0x2401B019
+                or cid == 0x2401B011
+            ):
                 Gbx.read_ghost_events(game_class, bp, cid)
-            elif cid == 0x309201c:
+            elif cid == 0x309201C:
                 bp.skip(32)
-            elif cid == 0x03093004 or cid == 0x2403f004:
+            elif cid == 0x03093004 or cid == 0x2403F004:
                 bp.skip(4 * 4)
             elif skipsize != -1:
                 bp.skip(skipsize)
@@ -728,9 +755,9 @@ class Gbx(object):
             game_class.control_names = []
             for _ in range(num_control_names):
                 name = bp.read_string_lookback()
-                if name != '':
+                if name != "":
                     game_class.control_names.append(name)
-                
+
             if len(game_class.control_names) == 0:
                 return
 
@@ -739,9 +766,11 @@ class Gbx(object):
             for _ in range(num_control_entries):
                 time = bp.read_uint32() - 100000
                 name = game_class.control_names[bp.read_byte()]
-                entry = headers.ControlEntry(time, name, bp.read_uint16(), bp.read_uint16()) 
+                entry = headers.ControlEntry(
+                    time, name, bp.read_uint16(), bp.read_uint16()
+                )
                 game_class.control_entries.append(entry)
-            
+
             game_class.game_version = bp.read_string()
             bp.skip(3 * 4)
             bp.read_string()
@@ -783,9 +812,14 @@ class Gbx(object):
             sample_pos = gr.pos
 
             record = headers.GhostSampleRecord(
-                gr.read_vec3(), gr.read_uint16(), gr.read_int16(),
-                gr.read_int16(), gr.read_int16(),
-                gr.read_int8(), gr.read_int8())
+                gr.read_vec3(),
+                gr.read_uint16(),
+                gr.read_int16(),
+                gr.read_int16(),
+                gr.read_int16(),
+                gr.read_int8(),
+                gr.read_int8(),
+            )
 
             len_sizes = len(sample_sizes)
             if i >= len_sizes:


### PR DESCRIPTION
In case an error is raised when creating a GBX object the file connection is not being closed which is required, if you want to continue working on the file (e.g. deleting it).

Also when I tried to import an exe file, it failed raising the GbxLoadError, because it could not decode as utf-8. That's why I added another try block to potentially raise an GbxLoadError.